### PR TITLE
Clear "already initialized constant Regexp::ENC_XXX" warnings.

### DIFF
--- a/lib/rspec/parameterized.rb
+++ b/lib/rspec/parameterized.rb
@@ -1,6 +1,6 @@
 require "rspec/parameterized/version"
-require 'ruby2ruby'
 require 'sourcify'
+require 'ruby2ruby'
 
 module RSpec
   module Parameterized


### PR DESCRIPTION
Requiring ruby2ruby emits "already initialized constant Regexp::ENC_XXX" warnings. And these warings disappear by requiring sourcify before ruby2ruby. See also http://github.com/ngty/sourcify/pull/23

Step to reproduce:

```
$ find . -type f
./Gemfile.lock
./Gemfile
./spec/sample_spec.rb
$ cat Gemfile
gem 'rspec'
gem 'rspec-parameterized'
$ cat Gemfile.lock
GEM
  specs:
    diff-lcs (1.2.4)
    file-tail (1.0.12)
      tins (~> 0.5)
    rspec (2.14.1)
      rspec-core (~> 2.14.0)
      rspec-expectations (~> 2.14.0)
      rspec-mocks (~> 2.14.0)
    rspec-core (2.14.5)
    rspec-expectations (2.14.2)
      diff-lcs (>= 1.1.3, < 2.0)
    rspec-mocks (2.14.3)
    rspec-parameterized (0.0.9)
      rspec (~> 2.13)
      ruby2ruby
      sourcify (~> 0.6.0.rc2)
    ruby2ruby (1.3.1)
      ruby_parser (~> 2.0)
      sexp_processor (~> 3.0)
    ruby_parser (2.3.1)
      sexp_processor (~> 3.0)
    sexp_processor (3.2.0)
    sourcify (0.6.0.rc4)
      file-tail (~> 1.0.10)
      ruby2ruby (~> 1.3.1)
      ruby_parser (~> 2.3.1)
      sexp_processor (~> 3.2.0)
    tins (0.9.0)

PLATFORMS
  ruby

DEPENDENCIES
  rspec
  rspec-parameterized
$ cat spec/sample_spec.rb
require 'rspec'
require 'rspec-parameterized'

describe String do
end
$ bundle exec rspec
/home/r/.rvm/gems/ruby-2.0.0-p247/gems/ruby_parser-2.3.1/lib/ruby_parser_extras.rb:10: warning: already initialized constant Regexp::ENC_NONE
/home/r/.rvm/gems/ruby-2.0.0-p247/gems/ruby2ruby-1.3.1/lib/ruby2ruby.rb:9: warning: previous definition of ENC_NONE was here
/home/r/.rvm/gems/ruby-2.0.0-p247/gems/ruby_parser-2.3.1/lib/ruby_parser_extras.rb:11: warning: already initialized constant Regexp::ENC_EUC
/home/r/.rvm/gems/ruby-2.0.0-p247/gems/ruby2ruby-1.3.1/lib/ruby2ruby.rb:10: warning: previous definition of ENC_EUC was here
/home/r/.rvm/gems/ruby-2.0.0-p247/gems/ruby_parser-2.3.1/lib/ruby_parser_extras.rb:12: warning: already initialized constant Regexp::ENC_SJIS
/home/r/.rvm/gems/ruby-2.0.0-p247/gems/ruby2ruby-1.3.1/lib/ruby2ruby.rb:11: warning: previous definition of ENC_SJIS was here
/home/r/.rvm/gems/ruby-2.0.0-p247/gems/ruby_parser-2.3.1/lib/ruby_parser_extras.rb:13: warning: already initialized constant Regexp::ENC_UTF8
/home/r/.rvm/gems/ruby-2.0.0-p247/gems/ruby2ruby-1.3.1/lib/ruby2ruby.rb:12: warning: previous definition of ENC_UTF8 was here
No examples found.


Finished in 0.00004 seconds
0 examples, 0 failures
```
