### PR TITLE
Accept nil/boolean for 1st column

### DIFF
--- a/lib/rspec/parameterized/table_syntax.rb
+++ b/lib/rspec/parameterized/table_syntax.rb
@@ -38,6 +38,18 @@ module RSpec
       refine Array do
         include TableSyntaxImplement
       end
+
+      refine NilClass do
+        include TableSyntaxImplement
+      end
+
+      refine TrueClass do
+        include TableSyntaxImplement
+      end
+
+      refine FalseClass do
+        include TableSyntaxImplement
+      end
     end
   end
 end

--- a/spec/parametarized_spec.rb
+++ b/spec/parametarized_spec.rb
@@ -178,6 +178,20 @@ describe RSpec::Parameterized do
         end
       end
     end
+    context "when 1st column is nil or true or false" do
+      using RSpec::Parameterized::TableSyntax
+      where(:a, :result) do
+        nil   | nil
+        false | false
+        true  | true
+      end
+
+      with_them do
+        it "a is result" do
+          expect(a).to be result
+        end
+      end
+    end
   end
 
   context "when the where has let variables, defined by parent example group" do


### PR DESCRIPTION
In case of using RSpec::Parameterized::TableSyntax, I can't use nil / true / false for 1st column.
It occurs syntax error.

```
/Users/ryonext/dev/rspec-parameterized/lib/rspec/parameterized.rb:139:in `define_cases': undefined method `to_params' for true:TrueClass (NoMethodError)
	from /Users/ryonext/dev/rspec-parameterized/lib/rspec/parameterized.rb:74:in `with_them'
```