### PR TITLE
allow hash arguments

### DIFF
--- a/lib/rspec/parameterized.rb
+++ b/lib/rspec/parameterized.rb
@@ -39,7 +39,8 @@ module RSpec
       #
       def where(*args, &b)
 
-        if args.size == 1 && (params = args[0]).instance_of?(Hash)
+        if args.size == 1 && args[0].instance_of?(Hash)
+          params = args[0]
           first, *rest = params.values
 
           set_parameters(params.keys, false) {

--- a/lib/rspec/parameterized.rb
+++ b/lib/rspec/parameterized.rb
@@ -40,11 +40,11 @@ module RSpec
       def where(*args, &b)
 
         if args.size == 1 && (params = args[0]).instance_of?(Hash)
-          first, *rest = params.keys
+          first, *rest = params.values
 
           set_parameters(params.keys, false) {
             rest_values = rest.map {|k| params[k] }
-            params[first].product(*rest_values)
+            first.product(*rest)
           }
         else
           set_parameters(args, false, &b)

--- a/lib/rspec/parameterized.rb
+++ b/lib/rspec/parameterized.rb
@@ -38,7 +38,17 @@ module RSpec
       #     end
       #
       def where(*args, &b)
-        set_parameters(args, false, &b)
+
+        if args.size == 1 && (params = args[0]).instance_of?(Hash)
+          first, *rest = params.keys
+
+          set_parameters(params.keys, false) {
+            rest_values = rest.map {|k| params[k] }
+            params[first].product(*rest_values)
+          }
+        else
+          set_parameters(args, false, &b)
+        end
       end
 
       # Set parameters to be bound in specs under this example group.

--- a/spec/parametarized_spec.rb
+++ b/spec/parametarized_spec.rb
@@ -50,6 +50,16 @@ describe RSpec::Parameterized do
     end
   end
 
+  describe "Hash arguments" do
+    where(a: [1, 3], b: [5, 7, 9], c: [2, 4])
+
+    with_them do
+      it "sums is even" do
+        expect(a + b + c).to be_even
+      end
+    end
+  end
+
   describe "table separated with pipe" do
     where_table(:a, :b, :answer) do
       1         | 2         | 3


### PR DESCRIPTION
test all combinations of values.

You can be described as follows.
```
# use Traditional 

where(:a, :b, :c) do
  [[1, 5, 2], [1, 5, 4], [1, 7, 2], [1, 7, 4], [1, 9, 2], [1, 9, 4], [3, 5, 2], [3, 5, 4], [3, 7, 2], [3, 7, 4], [3, 9, 2], [3, 9, 4]]
end

# use Hash argument
 where(a: [1, 3], b: [5, 7, 9], c: [2, 4])
```