### PR TITLE
Implement Hash parameter

### DIFF
--- a/spec/parametarized_spec.rb
+++ b/spec/parametarized_spec.rb
@@ -50,6 +50,27 @@ describe RSpec::Parameterized do
     end
   end
 
+  describe "hash parameter" do
+    where(:a, :b, :answer) do
+      {
+        1 => [2 , 3],
+        2 => [8 , 10],
+      }
+    end
+
+    with_them do
+      it "should do additions" do
+        expect(a + b).to eq answer
+      end
+    end
+
+    with_them pending: "PENDING" do
+      it "should do additions" do
+        expect(a + b).to == answer
+      end
+    end
+  end
+
   describe "table separated with pipe" do
     where_table(:a, :b, :answer) do
       1         | 2         | 3


### PR DESCRIPTION
I use rspec parameterized,recently.
And, that feel ugly when like a below table case. 

<table>
  <tr>
    <th>device</th>
    <th>status</th>
    <th>result</th>
  </tr>
  <tr>
    <th rowspan="2">smart_phone</th>
    <th>member</th>
    <td>return HTML</td>
  </tr>
  <tr>
    <th>not member</th>
    <td>redirect</td>
  </tr>
  <tr>
    <th rowspan="2">pc</th>
    <th>member</th>
    <td>return HTML</td>
  </tr>
  <tr>
    <th>not member</th>
    <td>recirect</td>
  </tr>
</table>

so, I fix code to use hash.

```ruby
where(:user_agent, :session_id, :lambda) do
{
   smart_phone_ua => {
    member_session_id => [->{ should be_success }],
    none_session_id => [->{ should be_redirect }],
  },
   pc_phone_ua => {
    member_session_id => [->{ should be_success }],
    none_session_id => [->{ should be_redirect }],
  }
}
end
```