### PR TITLE
Implement hash parameter

### DIFF
--- a/lib/rspec/parameterized.rb
+++ b/lib/rspec/parameterized.rb
@@ -148,22 +148,51 @@ module RSpec
           param_sets = separate_table_like_block(parameter.block)
         else
           extracted = instance.instance_eval(&parameter.block)
-          param_sets = extracted.is_a?(Array) ? extracted : extracted.to_params
+          if extracted.is_a?(Array)
+            param_sets = extracted
+          else
+            if extracted.respond_to?(:to_params)
+              param_sets = extracted.to_params
+            else
+              param_sets = extracted
+            end
+          end
         end
 
-        # for only one parameters
-        param_sets = param_sets.map { |x| Array[x] } if !param_sets[0].is_a?(Array)
+        keys = []
+        if param_sets.is_a?(Hash)
+          define_case_node(parameter, args, block, param_sets, keys)
+        else
+          # for only one parameters
+          param_sets = param_sets.map { |x| Array[x] } if !param_sets[0].is_a?(Array)
 
-        param_sets.each do |params|
-          pairs = [parameter.arg_names, params].transpose
-          pretty_params = pairs.map {|t| "#{t[0]}: #{params_inspect(t[1])}"}.join(", ")
-          describe(pretty_params, *args) do
-            pairs.each do |n|
-              let(n[0]) { n[1] }
-            end
-
-            module_eval(&block)
+          param_sets.each do |params|
+            define_assert(parameter, args, block, params, keys)
           end
+        end
+      end
+
+      def define_case_node(parameter, args, block, param_sets, keys)
+        if param_sets.is_a?(Hash)
+          param_sets.map do |key, params|
+            describe key.to_s do
+              define_case_node(parameter, args, block, params, keys+[key])
+            end
+          end
+        else
+          define_assert(parameter, args, block, param_sets, keys)
+        end
+      end
+
+      def define_assert(parameter, args, block, params, keys)
+        pairs = [parameter.arg_names, keys + params].transpose
+        pretty_params = pairs.map {|t| "#{t[0]}: #{params_inspect(t[1])}"}.join(", ")
+        describe(pretty_params, *args) do
+          pairs.each do |n|
+            let(n[0]) { n[1] }
+          end
+
+          module_eval(&block)
         end
       end
 

--- a/spec/parametarized_spec.rb
+++ b/spec/parametarized_spec.rb
@@ -60,6 +60,27 @@ describe RSpec::Parameterized do
     end
   end
 
+  describe "hash parameter" do
+    where(:a, :b, :answer) do
+      {
+        1 => [2 , 3],
+        2 => [8 , 10],
+      }
+    end
+
+    with_them do
+      it "should do additions" do
+        expect(a + b).to eq answer
+      end
+    end
+
+    with_them pending: "PENDING" do
+      it "should do additions" do
+        expect(a + b).to == answer
+      end
+    end
+  end
+
   describe "table separated with pipe" do
     where_table(:a, :b, :answer) do
       1         | 2         | 3


### PR DESCRIPTION
I use rspec parameterized,recently.
And, that feel ugly when like a below table case. 

<table>
  <tr>
    <th>device</th>
    <th>status</th>
    <th>result</th>
  </tr>
  <tr>
    <th rowspan="2">smart_phone</th>
    <th>member</th>
    <td>return HTML</td>
  </tr>
  <tr>
    <th>not member</th>
    <td>redirect</td>
  </tr>
  <tr>
    <th rowspan="2">pc</th>
    <th>member</th>
    <td>return HTML</td>
  </tr>
  <tr>
    <th>not member</th>
    <td>recirect</td>
  </tr>
</table>


so, I fix code to use hash parameter like below.

``` ruby
let(:smart_phone_ua){  'Mozilla/5.0 (iPhone; Mac OS X)'  }
let(:pc_phone_ua){ 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:18.0) Gecko Firefox/18.0' }
let(:member_session_id){ 1 }
let(:none_session_id) { nil }
where(:user_agent, :session_id, :lambda) do
{
   smart_phone_ua => {
    member_session_id => [->{ should be_success }],
    none_session_id => [->{ should be_redirect }],
  },
   pc_phone_ua => {
    member_session_id => [->{ should be_success }],
    none_session_id => [->{ should be_redirect }],
  }
}
end
```
