### PR TITLE
Set the caller of `.with_them` to metadata of ExampleGroup

### DIFF
--- a/lib/rspec/parameterized.rb
+++ b/lib/rspec/parameterized.rb
@@ -62,6 +62,10 @@ module RSpec
       #     end
       #
       def with_them(*args, &b)
+        opts = args.last.is_a?(Hash) ? args.pop : {}
+        opts[:caller] = caller unless opts[:caller]
+        args.push(opts)
+
         if @parameter.nil?
           @parameterized_pending_cases ||= []
           @parameterized_pending_cases << [args, b]


### PR DESCRIPTION
`RSpec::Parameterized::ExampleGroupMethods` calls `RSpec::Core::ExampleGroup.describe` via `.with_them`.

At that time, the metadata of ExapmleGroup is used `Proc#sorce_location` of block that have been passed to `RSpec::Core::ExampleGroup.describe`.

https://github.com/rspec/rspec-core/blob/v3.5.2/lib/rspec/core/metadata.rb#L150

This is the line that `RSpec::Parameterized::ExampleGroupMethods` was calling `RSpec::Core::ExampleGroup.describe`, not the line where you have to call `RSpec::Parameterized::ExampleGroupMethods.with_them`.

For example, if I use `RspecJUnitFormatter`, the difference of the output is 'classname' and 'file' in each testcase.

before:
```
<?xml version="1.0" encoding="UTF-8"?>
<testsuite name="rspec" tests="55" failures="0" errors="0" time="0.020887" timestamp="2016-08-17T20:54:54+09:00">
  <!-- Randomized with seed 56298 -->
  <properties/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized where and with_them a: 1, b: 2, answer: 3 should do additions" file="./lib/rspec/parameterized.rb" time="0.000149"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized where and with_them a: 5, b: 8, answer: 13 should do additions" file="./lib/rspec/parameterized.rb" time="0.000085"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized where and with_them a: 0, b: 0, answer: 0 should do additions" file="./lib/rspec/parameterized.rb" time="0.000081"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized where and with_them a: 1, b: 2, answer: 3 1 + 2 == 3" file="./lib/rspec/parameterized.rb" time="0.000078"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized where and with_them a: 5, b: 8, answer: 13 5 + 8 == 13" file="./lib/rspec/parameterized.rb" time="0.000074"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized where and with_them a: 0, b: 0, answer: 0 0 + 0 == 0" file="./lib/rspec/parameterized.rb" time="0.000077"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized where and with_them a: 1, b: 2, answer: 3 should do additions" file="./lib/rspec/parameterized.rb" time="0.000099">
    <skipped/>
  </testcase>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized where and with_them a: 5, b: 8, answer: 13 should do additions" file="./lib/rspec/parameterized.rb" time="0.000083">
    <skipped/>
  </testcase>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized where and with_them a: 0, b: 0, answer: 0 should do additions" file="./lib/rspec/parameterized.rb" time="0.000083">
    <skipped/>
  </testcase>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized lambda parameter a: 1, b: 2, answer: -&gt; {should == 3} should do additions" file="./lib/rspec/parameterized.rb" time="0.003039"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized lambda parameter a: 5, b: 8, answer: -&gt; {should == 13} should do additions" file="./lib/rspec/parameterized.rb" time="0.000115"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized lambda parameter a: 0, b: 0, answer: -&gt; {should == 0} should do additions" file="./lib/rspec/parameterized.rb" time="0.000081"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized Hash arguments a: 1, b: 5, c: 2 sums is even" file="./lib/rspec/parameterized.rb" time="0.001447"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized Hash arguments a: 1, b: 5, c: 4 sums is even" file="./lib/rspec/parameterized.rb" time="0.000099"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized Hash arguments a: 1, b: 7, c: 2 sums is even" file="./lib/rspec/parameterized.rb" time="0.000088"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized Hash arguments a: 1, b: 7, c: 4 sums is even" file="./lib/rspec/parameterized.rb" time="0.000086"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized Hash arguments a: 1, b: 9, c: 2 sums is even" file="./lib/rspec/parameterized.rb" time="0.000085"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized Hash arguments a: 1, b: 9, c: 4 sums is even" file="./lib/rspec/parameterized.rb" time="0.000083"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized Hash arguments a: 3, b: 5, c: 2 sums is even" file="./lib/rspec/parameterized.rb" time="0.000083"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized Hash arguments a: 3, b: 5, c: 4 sums is even" file="./lib/rspec/parameterized.rb" time="0.000080"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized Hash arguments a: 3, b: 7, c: 2 sums is even" file="./lib/rspec/parameterized.rb" time="0.000079"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized Hash arguments a: 3, b: 7, c: 4 sums is even" file="./lib/rspec/parameterized.rb" time="0.000080"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized Hash arguments a: 3, b: 9, c: 2 sums is even" file="./lib/rspec/parameterized.rb" time="0.000078"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized Hash arguments a: 3, b: 9, c: 4 sums is even" file="./lib/rspec/parameterized.rb" time="0.000081"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized table separated with pipe (using TableSyntax) a: 1, b: 2, answer: 3 a plus b is answer" file="./lib/rspec/parameterized.rb" time="0.000073"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized table separated with pipe (using TableSyntax) a: &quot;hello &quot;, b: &quot;world&quot;, answer: &quot;hello world&quot; a plus b is answer" file="./lib/rspec/parameterized.rb" time="0.000070"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized table separated with pipe (using TableSyntax) a: [1, 2, 3], b: [4, 5, 6], answer: [1, 2, 3, 4, 5, 6] a plus b is answer" file="./lib/rspec/parameterized.rb" time="0.000069"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized table separated with pipe and lambda parameter (using TableSyntax) a: 1, b: 2, matcher: -&gt; { eq(3) } a plus b is answer" file="./lib/rspec/parameterized.rb" time="0.000068"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized table separated with pipe and lambda parameter (using TableSyntax) a: &quot;hello &quot;, b: &quot;world&quot;, matcher: -&gt; { eq(&quot;hello world&quot;) } a plus b is answer" file="./lib/rspec/parameterized.rb" time="0.000070"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized table separated with pipe and lambda parameter (using TableSyntax) a: [1, 2, 3], b: [4, 5, 6], matcher: -&gt; { be_a(Array) } a plus b is answer" file="./lib/rspec/parameterized.rb" time="0.002341"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized when the where block is after with_them a: 1, b: 2, answer: 3 should do additions" file="./lib/rspec/parameterized.rb" time="0.000113"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized when the where block is after with_them a: 5, b: 8, answer: 13 should do additions" file="./lib/rspec/parameterized.rb" time="0.000078"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized when the where block is after with_them a: 0, b: 0, answer: 0 should do additions" file="./lib/rspec/parameterized.rb" time="0.000076"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized when the where block is after with_them a: 1, b: 2, answer: 3 should be a kind of Numeric" file="./lib/rspec/parameterized.rb" time="0.000192"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized when the where block is after with_them a: 5, b: 8, answer: 13 should be a kind of Numeric" file="./lib/rspec/parameterized.rb" time="0.000094"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized when the where block is after with_them a: 0, b: 0, answer: 0 should be a kind of Numeric" file="./lib/rspec/parameterized.rb" time="0.000091"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized when the where block is between with_thems a: 1, b: 2, answer: 3 should do additions" file="./lib/rspec/parameterized.rb" time="0.000076"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized when the where block is between with_thems a: 5, b: 8, answer: 13 should do additions" file="./lib/rspec/parameterized.rb" time="0.000073"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized when the where block is between with_thems a: 0, b: 0, answer: 0 should do additions" file="./lib/rspec/parameterized.rb" time="0.000073"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized when the where block is between with_thems a: 1, b: 2, answer: 3 should be a kind of Numeric" file="./lib/rspec/parameterized.rb" time="0.000091"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized when the where block is between with_thems a: 5, b: 8, answer: 13 should be a kind of Numeric" file="./lib/rspec/parameterized.rb" time="0.000089"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized when the where block is between with_thems a: 0, b: 0, answer: 0 should be a kind of Numeric" file="./lib/rspec/parameterized.rb" time="0.000087"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized when the where has only one parameter to be set x: 1 can take an array of elements" file="./lib/rspec/parameterized.rb" time="0.000070"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized when the where has only one parameter to be set x: 2 can take an array of elements" file="./lib/rspec/parameterized.rb" time="0.003254"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized when the where has only one parameter to be set x: 3 can take an array of elements" file="./lib/rspec/parameterized.rb" time="0.000062"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized when the table has only a row (using TableSyntax) a: 1, b: 2, answer: 3 a plus b is answer" file="./lib/rspec/parameterized.rb" time="0.000119"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized when 1st column is nil or true or false a: nil, result: nil a is result" file="./lib/rspec/parameterized.rb" time="0.000957"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized when 1st column is nil or true or false a: false, result: false a is result" file="./lib/rspec/parameterized.rb" time="0.000076"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized when 1st column is nil or true or false a: true, result: true a is result" file="./lib/rspec/parameterized.rb" time="0.000065"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized when the where has let variables, defined by parent example group parent (define let) child 1 a: 1, b: 2, answer: 3 a plus b is answer" file="./lib/rspec/parameterized.rb" time="0.000074"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized when the where has let variables, defined by parent example group parent (define let) child 1 a: 5, b: 8, answer: 13 a plus b is answer" file="./lib/rspec/parameterized.rb" time="0.000070"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized when the where has let variables, defined by parent example group parent (define let) child 3 (Using TableSyntax) a: 1, b: 2, answer: 3 a plus b is answer" file="./lib/rspec/parameterized.rb" time="0.000079"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized when the where has let variables, defined by parent example group parent (define let) child 3 (Using TableSyntax) a: 5, b: 8, answer: 13 a plus b is answer" file="./lib/rspec/parameterized.rb" time="0.000076"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized when the where has let variables, defined by parent example group parent (define let) child 3 (use matcher) a: 1, b: 2, matcher: #&lt;RSpec::Matchers::BuiltIn::Eq:0x007fb194388950 @expected=3&gt; a plus b is answer" file="./lib/rspec/parameterized.rb" time="0.000076"/>
  <testcase classname="lib.rspec.parameterized" name="RSpec::Parameterized when the where has let variables, defined by parent example group parent (define let) child 3 (use matcher) a: 5, b: 8, matcher: #&lt;RSpec::Matchers::BuiltIn::Eq:0x007fb194388888 @expected=13&gt; a plus b is answer" file="./lib/rspec/parameterized.rb" time="0.000073"/>
</testsuite>
```

after:
```
<?xml version="1.0" encoding="UTF-8"?>
<testsuite name="rspec" tests="55" failures="0" errors="0" time="0.017793" timestamp="2016-08-17T20:56:19+09:00">
  <!-- Randomized with seed 51794 -->
  <properties/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized where and with_them a: 1, b: 2, answer: 3 should do additions" file="./spec/parametarized_spec.rb" time="0.000136"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized where and with_them a: 5, b: 8, answer: 13 should do additions" file="./spec/parametarized_spec.rb" time="0.000071"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized where and with_them a: 0, b: 0, answer: 0 should do additions" file="./spec/parametarized_spec.rb" time="0.000081"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized where and with_them a: 1, b: 2, answer: 3 1 + 2 == 3" file="./spec/parametarized_spec.rb" time="0.000087"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized where and with_them a: 5, b: 8, answer: 13 5 + 8 == 13" file="./spec/parametarized_spec.rb" time="0.000088"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized where and with_them a: 0, b: 0, answer: 0 0 + 0 == 0" file="./spec/parametarized_spec.rb" time="0.000086"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized where and with_them a: 1, b: 2, answer: 3 should do additions" file="./spec/parametarized_spec.rb" time="0.000111">
    <skipped/>
  </testcase>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized where and with_them a: 5, b: 8, answer: 13 should do additions" file="./spec/parametarized_spec.rb" time="0.000080">
    <skipped/>
  </testcase>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized where and with_them a: 0, b: 0, answer: 0 should do additions" file="./spec/parametarized_spec.rb" time="0.000082">
    <skipped/>
  </testcase>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized lambda parameter a: 1, b: 2, answer: -&gt; {should == 3} should do additions" file="./spec/parametarized_spec.rb" time="0.002169"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized lambda parameter a: 5, b: 8, answer: -&gt; {should == 13} should do additions" file="./spec/parametarized_spec.rb" time="0.000100"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized lambda parameter a: 0, b: 0, answer: -&gt; {should == 0} should do additions" file="./spec/parametarized_spec.rb" time="0.000088"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized Hash arguments a: 1, b: 5, c: 2 sums is even" file="./spec/parametarized_spec.rb" time="0.001096"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized Hash arguments a: 1, b: 5, c: 4 sums is even" file="./spec/parametarized_spec.rb" time="0.000095"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized Hash arguments a: 1, b: 7, c: 2 sums is even" file="./spec/parametarized_spec.rb" time="0.000082"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized Hash arguments a: 1, b: 7, c: 4 sums is even" file="./spec/parametarized_spec.rb" time="0.000081"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized Hash arguments a: 1, b: 9, c: 2 sums is even" file="./spec/parametarized_spec.rb" time="0.000078"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized Hash arguments a: 1, b: 9, c: 4 sums is even" file="./spec/parametarized_spec.rb" time="0.000080"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized Hash arguments a: 3, b: 5, c: 2 sums is even" file="./spec/parametarized_spec.rb" time="0.000077"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized Hash arguments a: 3, b: 5, c: 4 sums is even" file="./spec/parametarized_spec.rb" time="0.000078"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized Hash arguments a: 3, b: 7, c: 2 sums is even" file="./spec/parametarized_spec.rb" time="0.000078"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized Hash arguments a: 3, b: 7, c: 4 sums is even" file="./spec/parametarized_spec.rb" time="0.000076"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized Hash arguments a: 3, b: 9, c: 2 sums is even" file="./spec/parametarized_spec.rb" time="0.000077"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized Hash arguments a: 3, b: 9, c: 4 sums is even" file="./spec/parametarized_spec.rb" time="0.000074"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized table separated with pipe (using TableSyntax) a: 1, b: 2, answer: 3 a plus b is answer" file="./spec/parametarized_spec.rb" time="0.000067"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized table separated with pipe (using TableSyntax) a: &quot;hello &quot;, b: &quot;world&quot;, answer: &quot;hello world&quot; a plus b is answer" file="./spec/parametarized_spec.rb" time="0.000178"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized table separated with pipe (using TableSyntax) a: [1, 2, 3], b: [4, 5, 6], answer: [1, 2, 3, 4, 5, 6] a plus b is answer" file="./spec/parametarized_spec.rb" time="0.000083"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized table separated with pipe and lambda parameter (using TableSyntax) a: 1, b: 2, matcher: -&gt; { eq(3) } a plus b is answer" file="./spec/parametarized_spec.rb" time="0.000079"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized table separated with pipe and lambda parameter (using TableSyntax) a: &quot;hello &quot;, b: &quot;world&quot;, matcher: -&gt; { eq(&quot;hello world&quot;) } a plus b is answer" file="./spec/parametarized_spec.rb" time="0.000077"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized table separated with pipe and lambda parameter (using TableSyntax) a: [1, 2, 3], b: [4, 5, 6], matcher: -&gt; { be_a(Array) } a plus b is answer" file="./spec/parametarized_spec.rb" time="0.000405"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized when the where block is after with_them a: 1, b: 2, answer: 3 should do additions" file="./spec/parametarized_spec.rb" time="0.000098"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized when the where block is after with_them a: 5, b: 8, answer: 13 should do additions" file="./spec/parametarized_spec.rb" time="0.000077"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized when the where block is after with_them a: 0, b: 0, answer: 0 should do additions" file="./spec/parametarized_spec.rb" time="0.000074"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized when the where block is after with_them a: 1, b: 2, answer: 3 should be a kind of Numeric" file="./spec/parametarized_spec.rb" time="0.000185"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized when the where block is after with_them a: 5, b: 8, answer: 13 should be a kind of Numeric" file="./spec/parametarized_spec.rb" time="0.000096"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized when the where block is after with_them a: 0, b: 0, answer: 0 should be a kind of Numeric" file="./spec/parametarized_spec.rb" time="0.000093"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized when the where block is between with_thems a: 1, b: 2, answer: 3 should do additions" file="./spec/parametarized_spec.rb" time="0.000082"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized when the where block is between with_thems a: 5, b: 8, answer: 13 should do additions" file="./spec/parametarized_spec.rb" time="0.000115"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized when the where block is between with_thems a: 0, b: 0, answer: 0 should do additions" file="./spec/parametarized_spec.rb" time="0.000068"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized when the where block is between with_thems a: 1, b: 2, answer: 3 should be a kind of Numeric" file="./spec/parametarized_spec.rb" time="0.000184"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized when the where block is between with_thems a: 5, b: 8, answer: 13 should be a kind of Numeric" file="./spec/parametarized_spec.rb" time="0.000080"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized when the where block is between with_thems a: 0, b: 0, answer: 0 should be a kind of Numeric" file="./spec/parametarized_spec.rb" time="0.000151"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized when the where has only one parameter to be set x: 1 can take an array of elements" file="./spec/parametarized_spec.rb" time="0.000064"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized when the where has only one parameter to be set x: 2 can take an array of elements" file="./spec/parametarized_spec.rb" time="0.000118"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized when the where has only one parameter to be set x: 3 can take an array of elements" file="./spec/parametarized_spec.rb" time="0.000061"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized when the table has only a row (using TableSyntax) a: 1, b: 2, answer: 3 a plus b is answer" file="./spec/parametarized_spec.rb" time="0.000113"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized when 1st column is nil or true or false a: nil, result: nil a is result" file="./spec/parametarized_spec.rb" time="0.000628"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized when 1st column is nil or true or false a: false, result: false a is result" file="./spec/parametarized_spec.rb" time="0.000075"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized when 1st column is nil or true or false a: true, result: true a is result" file="./spec/parametarized_spec.rb" time="0.000066"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized when the where has let variables, defined by parent example group parent (define let) child 1 a: 1, b: 2, answer: 3 a plus b is answer" file="./spec/parametarized_spec.rb" time="0.000074"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized when the where has let variables, defined by parent example group parent (define let) child 1 a: 5, b: 8, answer: 13 a plus b is answer" file="./spec/parametarized_spec.rb" time="0.000069"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized when the where has let variables, defined by parent example group parent (define let) child 3 (Using TableSyntax) a: 1, b: 2, answer: 3 a plus b is answer" file="./spec/parametarized_spec.rb" time="0.000070"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized when the where has let variables, defined by parent example group parent (define let) child 3 (Using TableSyntax) a: 5, b: 8, answer: 13 a plus b is answer" file="./spec/parametarized_spec.rb" time="0.000068"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized when the where has let variables, defined by parent example group parent (define let) child 3 (use matcher) a: 1, b: 2, matcher: #&lt;RSpec::Matchers::BuiltIn::Eq:0x007f98baef1a78 @expected=3&gt; a plus b is answer" file="./spec/parametarized_spec.rb" time="0.000069"/>
  <testcase classname="spec.parametarized_spec" name="RSpec::Parameterized when the where has let variables, defined by parent example group parent (define let) child 3 (use matcher) a: 5, b: 8, matcher: #&lt;RSpec::Matchers::BuiltIn::Eq:0x007f98baef19b0 @expected=13&gt; a plus b is answer" file="./spec/parametarized_spec.rb" time="0.000068"/>
</testsuite>
```