### PR TITLE
Fix deprecation warning on ruby 2.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 rvm:
   - 2.2
   - 2.3.0
+  - 2.4.0
   - ruby-head
 
 gemfile:

--- a/lib/rspec/parameterized/table_syntax.rb
+++ b/lib/rspec/parameterized/table_syntax.rb
@@ -27,12 +27,18 @@ module RSpec
         include TableSyntaxImplement
       end
 
-      refine Fixnum do
-        include TableSyntaxImplement
-      end
+      if Gem::Version.create(RUBY_VERSION) >= Gem::Version.create("2.4.0")
+        refine Integer do
+          include TableSyntaxImplement
+        end
+      else
+        refine Fixnum do
+          include TableSyntaxImplement
+        end
 
-      refine Bignum do
-        include TableSyntaxImplement
+        refine Bignum do
+          include TableSyntaxImplement
+        end
       end
 
       refine Array do

--- a/rspec-parameterized.gemspec
+++ b/rspec-parameterized.gemspec
@@ -14,7 +14,7 @@ I was inspired by [udzura's mock](https://gist.github.com/1881139).}
   gem.add_dependency('unparser')
   gem.add_dependency('proc_to_ast')
   gem.add_dependency('binding_of_caller')
-  gem.add_development_dependency('rake')
+  gem.add_development_dependency('rake', '< 12.0.0')
 
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }

--- a/spec/parametarized_spec.rb
+++ b/spec/parametarized_spec.rb
@@ -74,6 +74,7 @@ describe RSpec::Parameterized do
         1         | 2         | 3
         "hello "  | "world"   | "hello world"
         [1, 2, 3] | [4, 5, 6] | [1, 2, 3, 4, 5, 6]
+        100000000000000000000 | 100000000000000000000 | 200000000000000000000
       end
 
       with_them do
@@ -90,6 +91,7 @@ describe RSpec::Parameterized do
         1         | 2         | -> { eq(3) }
         "hello "  | "world"   | -> { eq("hello world") }
         [1, 2, 3] | [4, 5, 6] | -> { be_a(Array) }
+        100000000000000000000 | 100000000000000000000 | -> { eq(200000000000000000000) }
       end
 
       with_them do


### PR DESCRIPTION
`Fixnum` and `Bignum` are deprecated since ruby 2.4

```sh
$ ruby -v
ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-darwin13]

$ bundle exec rspec
(snip)
/Users/sue445/dev/workspace/github.com/tomykaira/rspec-parameterized/lib/rspec/parameterized/table_syntax.rb:30: warning: constant ::Fixnum is deprecated
/Users/sue445/dev/workspace/github.com/tomykaira/rspec-parameterized/lib/rspec/parameterized/table_syntax.rb:34: warning: constant ::Bignum is deprecated
```