### PR TITLE
Customizable description

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ describe "plus" do
 end
 
 # It's also possible to override each combination name using magic variable :case_name
+# Output:
+# Custom test case name
+#   positive integers
+#     should do additions
+#   negative integers
+#     should do additions
+#   mixed integers
+#     should do additions
 describe "Custom names for regular syntax" do
   where(:case_name, :a, :b, :answer) do
     [
@@ -87,16 +95,18 @@ describe "Custom names for regular syntax" do
     it "should do additions" do
       expect(a + b).to eq answer
   end
-# Output:
-# Custom test case name
-#   positive integers
-#     should do additions
-#   negative integers
-#     should do additions
-#   mixed integers
-#     should do additions
+end
 
 # Or :case_names lambda for hash syntax
+# Output:
+# when hash arguments
+#   1 + 5 + 2
+#     sum is even
+#   1 + 5 + 4
+#     sum is even
+#   1 + 7 + 2
+#     sum is even
+#   ...
 describe "Custom naming for hash syntax" do
   where(case_names: ->(a, b, c){"#{a} + #{b} + #{c}"}, a: [1, 3], b: [5, 7, 9], c: [2, 4])
 
@@ -107,15 +117,6 @@ describe "Custom naming for hash syntax" do
   end
 end
 
-# Output:
-# when hash arguments
-#   1 + 5 + 2
-#     sum is even
-#   1 + 5 + 4
-#     sum is even
-#   1 + 7 + 2
-#     sum is even
-#   ...
 ```
 
 I was inspired by [udzura's mock](https://gist.github.com/1881139).

--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ end
 describe "Custom names for regular syntax" do
   where(:case_name, :a, :b, :answer) do
     [
-        ["positive integers",  6,  2,  8],
-        ["negative integers", -1, -2, -3],
-        [   "mixed integers", -5,  3, -2],
+      ["positive integers",  6,  2,  8],
+      ["negative integers", -1, -2, -3],
+      [   "mixed integers", -5,  3, -2],
     ]
   end
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,50 @@ describe "plus" do
     end
   end
 end
+
+# It's also possible to override each combination name using magic variable :case_name
+describe "Custom names for regular syntax" do
+  where(:case_name, :a, :b, :answer) do
+    [
+        ["positive integers",  6,  2,  8],
+        ["negative integers", -1, -2, -3],
+        [   "mixed integers", -5,  3, -2],
+    ]
+  end
+
+  with_them do
+    it "should do additions" do
+      expect(a + b).to eq answer
+  end
+# Output:
+# Custom test case name
+#   positive integers
+#     should do additions
+#   negative integers
+#     should do additions
+#   mixed integers
+#     should do additions
+
+# Or :case_names lambda for hash syntax
+describe "Custom naming for hash syntax" do
+  where(case_names: ->(a, b, c){"#{a} + #{b} + #{c}"}, a: [1, 3], b: [5, 7, 9], c: [2, 4])
+
+  with_them do
+    it "sum is even" do
+      expect(a + b + c).to be_even
+    end
+  end
+end
+
+# Output:
+# when hash arguments
+#   1 + 5 + 2
+#     sum is even
+#   1 + 5 + 4
+#     sum is even
+#   1 + 7 + 2
+#     sum is even
+#   ...
 ```
 
 I was inspired by [udzura's mock](https://gist.github.com/1881139).

--- a/spec/parametarized_spec.rb
+++ b/spec/parametarized_spec.rb
@@ -70,9 +70,9 @@ describe RSpec::Parameterized do
     context "when regular arguments" do
       where(:case_name, :a, :b, :answer) do
         [
-            ["positive integers",  6,  2,  8],
-            ["negative integers", -1, -2, -3],
-            [   "mixed integers", -5,  3, -2],
+          ["positive integers",  6,  2,  8],
+          ["negative integers", -1, -2, -3],
+          [   "mixed integers", -5,  3, -2],
         ]
       end
 

--- a/spec/parametarized_spec.rb
+++ b/spec/parametarized_spec.rb
@@ -66,6 +66,66 @@ describe RSpec::Parameterized do
     end
   end
 
+  describe "Custom test case name" do
+    context "when regular arguments" do
+      where(:case_name, :a, :b, :answer) do
+        [
+            ["positive integers",  6,  2,  8],
+            ["negative integers", -1, -2, -3],
+            [   "mixed integers", -5,  3, -2],
+        ]
+      end
+
+      with_them do
+        it "should do additions" do
+          expect(a + b).to eq answer
+        end
+
+        it "should have custom test name" do |example|
+          expect(example.metadata[:example_group][:description]).to eq case_name
+        end
+      end
+    end
+
+    context "when hash arguments" do
+      where(case_names: ->(a, b, c){"#{a} + #{b} + #{c}"}, a: [1, 3], b: [5, 7, 9], c: [2, 4])
+
+      with_them do
+        it "sum is even" do
+          expect(a + b + c).to be_even
+        end
+
+        it "should have custom names" do |example|
+          expect(example.metadata[:example_group][:description]).to include "+"
+        end
+      end
+    end
+
+    if RUBY_VERSION >= "2,1"
+      context "when arguments are separated with pipe (using TableSyntax)" do
+        using RSpec::Parameterized::TableSyntax
+
+        where(:case_name, :a, :b, :answer) do
+          "integers"      | 1                     | 2                     | 3
+          "strings"       | "hello "              | "world"               | "hello world"
+          "arrays"        | [1, 2, 3]             | [4, 5, 6]             | [1, 2, 3, 4, 5, 6]
+          "giant numbers" | 100000000000000000000 | 100000000000000000000 | 200000000000000000000
+        end
+
+        with_them do
+          it "a plus b is answer" do
+            expect(a + b).to eq answer
+          end
+
+          it "should have custom test name" do |example|
+            expect(example.metadata[:example_group][:description]).to eq case_name
+          end
+        end
+      end
+    end
+
+  end
+
   if RUBY_VERSION >= "2.1"
     describe "table separated with pipe (using TableSyntax)" do
       using RSpec::Parameterized::TableSyntax


### PR DESCRIPTION
This PR allows users to specify custom descriptions using magic argument :case_name
```
describe "Custom names for regular syntax" do
  where(:case_name, :a, :b, :answer) do
    [
        ["positive integers",  6,  2,  8],
        ["negative integers", -1, -2, -3],
        [   "mixed integers", -5,  3, -2],
    ]
  end

  with_them do
    it "should do additions" do
      expect(a + b).to eq answer
  end
end

# Output:
# Custom test case name
#   positive integers
#     should do additions
#   negative integers
#     should do additions
#   mixed integers
#     should do additions
```

For hash syntax you can specify a lambda that would be fed with other arguments:
```
describe "Custom naming for hash syntax" do
  where(case_names: ->(a, b, c){"#{a} + #{b} + #{c}"}, a: [1, 3], b: [5, 7, 9], c: [2, 4])

  with_them do
    it "sum is even" do
      expect(a + b + c).to be_even
    end
  end
end
# Output:
# when hash arguments
#   1 + 5 + 2
#     sum is even
#   1 + 5 + 4
#     sum is even
#   1 + 7 + 2
#     sum is even
#   ...
```

Maybe not the most elegant solution, but I've been using it for a while and it's better then nothing.