### PR TITLE
Verbose test syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,36 @@ describe "plus" do
   end
 end
 
+# Verbose Syntax
+# For complex inputs or if you just want to be super explicit
+describe "Verbose syntax" do
+  where do
+    {
+        "positive integers" => {
+            a: 1,
+            b: 2,
+            answer: 3,
+        },
+        "negative_integers" => {
+            a: -1,
+            b: -2,
+            answer: -3,
+        },
+        "mixed_integers" => {
+            a: 3,
+            b: -3,
+            answer: 0,
+        },
+    }
+  end
+
+  with_them do
+    it "should do additions" do
+      expect(a + b).to eq answer
+    end
+  end
+end
+
 # It's also possible to override each combination name using magic variable :case_name
 # Output:
 # Custom test case name

--- a/README.md
+++ b/README.md
@@ -78,21 +78,21 @@ end
 describe "Verbose syntax" do
   where do
     {
-        "positive integers" => {
-            a: 1,
-            b: 2,
-            answer: 3,
-        },
-        "negative_integers" => {
-            a: -1,
-            b: -2,
-            answer: -3,
-        },
-        "mixed_integers" => {
-            a: 3,
-            b: -3,
-            answer: 0,
-        },
+      "positive integers" => {
+        a: 1,
+        b: 2,
+        answer: 3,
+      },
+      "negative_integers" => {
+        a: -1,
+        b: -2,
+        answer: -3,
+      },
+      "mixed_integers" => {
+        a: 3,
+        b: -3,
+        answer: 0,
+      },
     }
   end
 

--- a/lib/rspec/parameterized.rb
+++ b/lib/rspec/parameterized.rb
@@ -54,6 +54,8 @@ module RSpec
           set_parameters(arg_names) {
             arg_values
           }
+        elsif args.size == 0
+          set_verbose_parameters(&b)
         else
           set_parameters(args, &b)
         end
@@ -142,6 +144,23 @@ module RSpec
         rescue Parser::SyntaxError
           return obj.inspect
         end
+      end
+
+      def set_verbose_parameters(&block)
+        arguments_hash = yield
+        arg_names = arguments_hash.values.reduce(Set.new) { |memo, pairs| memo | pairs.keys }.to_a
+        arg_values = []
+        arguments_hash.each do |name, values_hash|
+          row = [name]
+          arg_names.each do |argument_name|
+              row << values_hash[argument_name]
+          end
+          arg_values << row
+        end
+        arg_names.unshift(:case_name)
+        set_parameters(arg_names) {
+          arg_values
+        }
       end
     end
   end

--- a/spec/parametarized_spec.rb
+++ b/spec/parametarized_spec.rb
@@ -69,21 +69,21 @@ describe RSpec::Parameterized do
   describe "Verbose syntax" do
     where do
       {
-          "positive integers" => {
-              a: 1,
-              b: 2,
-              answer: 3,
-          },
-          "negative_integers" => {
-              a: -1,
-              b: -2,
-              answer: -3,
-          },
-          "mixed_integers" => {
-              a: 3,
-              b: -3,
-              answer: 0,
-          },
+        "positive integers" => {
+          a: 1,
+          b: 2,
+          answer: 3,
+        },
+        "negative_integers" => {
+          a: -1,
+          b: -2,
+          answer: -3,
+        },
+        "mixed_integers" => {
+          a: 3,
+          b: -3,
+          answer: 0,
+        },
       }
     end
 
@@ -100,21 +100,21 @@ describe RSpec::Parameterized do
     context "lambda parameter" do
       where do
         {
-            "integers" => {
-                a: 1,
-                b: 2,
-                answer: -> {expect(subject).to eq 3},
-            },
-            "strings" => {
-                a: "hello ",
-                b: "world",
-                answer: -> {expect(subject).to include "lo wo"},
-            },
-            "arrays" => {
-                a: [1, 2, 3],
-                b: [4, 5, 6],
-                answer: -> {expect(subject.size).to eq 6}
-            }
+          "integers" => {
+            a: 1,
+            b: 2,
+            answer: -> {expect(subject).to eq 3},
+          },
+          "strings" => {
+            a: "hello ",
+            b: "world",
+            answer: -> {expect(subject).to include "lo wo"},
+          },
+          "arrays" => {
+            a: [1, 2, 3],
+            b: [4, 5, 6],
+            answer: -> {expect(subject.size).to eq 6}
+          }
         }
       end
 

--- a/spec/parametarized_spec.rb
+++ b/spec/parametarized_spec.rb
@@ -66,6 +66,71 @@ describe RSpec::Parameterized do
     end
   end
 
+  describe "Verbose syntax" do
+    where do
+      {
+          "positive integers" => {
+              a: 1,
+              b: 2,
+              answer: 3,
+          },
+          "negative_integers" => {
+              a: -1,
+              b: -2,
+              answer: -3,
+          },
+          "mixed_integers" => {
+              a: 3,
+              b: -3,
+              answer: 0,
+          },
+      }
+    end
+
+    with_them do
+      it "should do additions" do
+        expect(a + b).to eq answer
+      end
+
+      it "should have custom name" do |example|
+        expect(example.metadata[:example_group][:description]).to eq case_name
+      end
+    end
+
+    context "lambda parameter" do
+      where do
+        {
+            "integers" => {
+                a: 1,
+                b: 2,
+                answer: -> {expect(subject).to eq 3},
+            },
+            "strings" => {
+                a: "hello ",
+                b: "world",
+                answer: -> {expect(subject).to include "lo wo"},
+            },
+            "arrays" => {
+                a: [1, 2, 3],
+                b: [4, 5, 6],
+                answer: -> {expect(subject.size).to eq 6}
+            }
+        }
+      end
+
+      with_them do
+        subject {a + b}
+        it "should do additions" do
+          self.instance_exec(&answer)
+        end
+
+        it "should have custom name" do |example|
+          expect(example.metadata[:example_group][:description]).to eq(case_name)
+        end
+      end
+    end
+  end
+
   describe "Custom test case name" do
     context "when regular arguments" do
       where(:case_name, :a, :b, :answer) do


### PR DESCRIPTION
Context: I'm using rspec for high-level integration tests and they very often carry a lot of verbose input arguments (such as hashes or arrays). For those cases I found it very convenient to represent tests as a hash of hashes:
```
describe "Verbose syntax" do
  where do
    {
        "positive integers" => {
            a: 1,
            b: 2,
            answer: 3,
        },
        "negative_integers" => {
            a: -1,
            b: -2,
            answer: -3,
        },
        "mixed_integers" => {
            a: 3,
            b: -3,
            answer: 0,
        },
    }
  end

  with_them do
    it "should do additions" do
      expect(a + b).to eq answer
    end
  end
end
```

or if you want some (almost) actual usage example:
```
where do
      {
          'the mots simple combinations of settings' => {
              settings: {
                  'my_user_1' => 'none',
                  'my_user_2' => 'none'
              },
              outcome: %w(my_user_1 my_user_2)
          },
          'a little bit more interesting case' => {
              settings: {
                  'my_user_1' => 'mode1',
                  'my_user_2' => 'none'
              },
              outcome: %w(my_user_1 my_user_2 my_user_3)
          },
          'a case with more users' => {
              settings: {
                  'my_user_1' => 'mode2',
                  'my_user_2' => 'none',
                  'my_user_3' => 'none',
                  'my_user_4' => 'none'
              },
              outcome: %w(my_user_1 my_user_2 my_user_3)
          },
          'more stuff' => {
              settings: {
                  'my_user_1' => 'mode3',
                  'my_user_2' => 'none',
                  'my_user_3' => 'none',
                  'my_user_4' => 'none'
              },
              outcome: %w(my_user_1 my_user_2 my_user_3)
          },
          'even more stuff' => {
              settings: {
                  'my_user_1' => 'mode3',
                  'my_user_2' => 'none',
                  'my_user_3' => 'none',
                  'my_user_4' => 'mode2',
                  'my_user_5' => 'none'
              },
              outcome: %w(my_user_1 my_user_2 my_user_3 my_user_4)
          },
          'last case' => {
              settings: {
                  'my_user_1' => 'mode3',
                  'my_user_2' => 'none',
                  'my_user_3' => 'none',
                  'my_user_4' => 'mode3',
                  'my_user_5' => 'none'
              },
              outcome: %w(my_user_1 my_user_2 my_user_3 my_user_4 my_user_5)
          }
      }
    end
```

Note that this feature depends on https://github.com/tomykaira/rspec-parameterized/pull/41 (and in fact includes it - I didn't know how to avoid this)