### PR TITLE
Replace binding_of_caller with binding_ninja

### DIFF
--- a/lib/rspec/parameterized/table_syntax.rb
+++ b/lib/rspec/parameterized/table_syntax.rb
@@ -1,12 +1,13 @@
-require 'binding_of_caller'
 require 'rspec/parameterized/table'
+require 'binding_ninja'
 
 module RSpec
   module Parameterized
     module TableSyntaxImplement
-      def |(other)
-        where_binding = binding.of_caller(1)          # get where block binding
-        caller_instance = eval("self", where_binding) # get caller instance (ExampleGroup)
+      extend BindingNinja
+
+      def |(where_binding, other)
+        caller_instance = where_binding.receiver # get caller instance (ExampleGroup)
 
         if caller_instance.instance_variable_defined?(:@__parameter_table)
           table = caller_instance.instance_variable_get(:@__parameter_table)
@@ -20,6 +21,7 @@ module RSpec
         row.add_param(other)
         table
       end
+      auto_inject_binding :|
     end
 
     module TableSyntax

--- a/rspec-parameterized.gemspec
+++ b/rspec-parameterized.gemspec
@@ -13,7 +13,7 @@ I was inspired by [udzura's mock](https://gist.github.com/1881139).}
   gem.add_dependency('parser')
   gem.add_dependency('unparser')
   gem.add_dependency('proc_to_ast')
-  gem.add_dependency('binding_of_caller')
+  gem.add_dependency('binding_ninja')
   gem.add_development_dependency('rake', '< 12.0.0')
 
   gem.files         = `git ls-files`.split($\)


### PR DESCRIPTION
I developed `binding_ninja` simple and lightweight alternative of `binding_of_caller`.

https://github.com/joker1007/binding_ninja

I replaced table_syntax implementation with `binding_ninja`