### PR TITLE
Use binding_ninja v0.2.1+

### DIFF
--- a/rspec-parameterized.gemspec
+++ b/rspec-parameterized.gemspec
@@ -13,7 +13,7 @@ I was inspired by [udzura's mock](https://gist.github.com/1881139).}
   gem.add_dependency('parser')
   gem.add_dependency('unparser')
   gem.add_dependency('proc_to_ast')
-  gem.add_dependency('binding_ninja')
+  gem.add_dependency('binding_ninja', '>= 0.2.1')
   gem.add_development_dependency('rake', '< 12.0.0')
 
   gem.files         = `git ls-files`.split($\)


### PR DESCRIPTION
details #45 

When using `binding_ninja` v0.2.0, rspec is failed. 

This problem is fixed at v0.2.1. So I think that it would be better to avoid v0.2.0

Close #45 