### PR TITLE
Stop `gem update --system`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ gemfile:
   - gemfiles/rspec3.3.gemfile
   - gemfiles/rspec3.4.gemfile
 
-before_install:
-  - gem update --system --no-document
-
 matrix:
   allow_failures:
     - rvm: ruby-head


### PR DESCRIPTION
rubygems v3+ requires MRI 2.3+
https://rubygems.org/gems/rubygems-update/versions/3.0.0

So build will be failed on MRI < 2.3