### PR TITLE
Travis: Remove unused sudo: false directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 cache: bundler
-sudo: false
 rvm:
   - 2.4
   - 2.5


### PR DESCRIPTION
  - See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration for more details