### PR TITLE
CI: Use latest jruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 2.5
   - 2.6
   - ruby-head
-  - jruby-9.2.7.0
+  - jruby-9.2.8.0
 
 gemfile:
   - gemfiles/rspec3.4.gemfile


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.8.0**.

[JRuby 9.2.8.0 release blog post](https://www.jruby.org/2019/08/12/jruby-9-2-8-0.html)