### PR TITLE
Add new parameter type: ref and lazy.

### DIFF
--- a/lib/rspec/parameterized/arg.rb
+++ b/lib/rspec/parameterized/arg.rb
@@ -1,0 +1,7 @@
+module RSpec
+  module Parameterized
+    class Arg
+      def apply(obj) ; end
+    end
+  end
+end

--- a/lib/rspec/parameterized/helper_methods.rb
+++ b/lib/rspec/parameterized/helper_methods.rb
@@ -1,0 +1,20 @@
+require 'rspec/parameterized/ref_arg'
+require 'rspec/parameterized/lazy_arg'
+module RSpec
+  module Parameterized
+    module HelperMethods
+      def ref(symbol)
+        RefArg.new(symbol)
+      end
+
+      def lazy(&block)
+        LazyArg.new(&block)
+      end
+
+      def self.applicable?(arg)
+        arg.is_a? Arg
+      end
+    end
+  end
+end
+

--- a/lib/rspec/parameterized/lazy_arg.rb
+++ b/lib/rspec/parameterized/lazy_arg.rb
@@ -1,0 +1,13 @@
+module RSpec
+  module Parameterized
+    class LazyArg < Arg
+      def initialize(&block)
+        @block = block
+      end
+
+      def apply(obj)
+        obj.instance_eval(&@block)
+      end
+    end
+  end
+end

--- a/lib/rspec/parameterized/ref_arg.rb
+++ b/lib/rspec/parameterized/ref_arg.rb
@@ -1,0 +1,15 @@
+require 'rspec/parameterized/arg'
+module RSpec
+  module Parameterized
+    class RefArg < Arg
+      def initialize(symbol)
+        @symbol = symbol
+      end
+
+      def apply(obj)
+        obj.send(@symbol)
+      end
+    end
+  end
+end
+

--- a/spec/parametarized_spec.rb
+++ b/spec/parametarized_spec.rb
@@ -191,6 +191,52 @@ describe RSpec::Parameterized do
 
   end
 
+  describe "ref" do
+    let(:foo) { 1 }
+
+    where(:value, :answer) do
+      [
+        [ref(:foo), 1],
+      ]
+    end
+
+    with_them do
+      it "let variable in same example group can be used" do
+        expect(value).to eq answer
+      end
+
+      context "override let varibale" do
+        let(:foo) { 3 }
+
+        it "can override let variable" do
+          expect(value).to eq 3
+        end
+      end
+    end
+  end
+
+  describe "lazy" do
+    let(:one) { 1 }
+    let(:four) { 4 }
+
+    where(:a, :b, :answer) do
+      [
+        [ref(:one), ref(:four), lazy { two + three }],
+      ]
+    end
+
+    with_them do
+      context "define two and three after where block" do
+        let(:two) { 2 }
+        let(:three) { 3 }
+
+        it "should do additions" do
+          expect(a + b).to eq answer
+        end
+      end
+    end
+  end
+
   if RUBY_VERSION >= "2.1"
     describe "table separated with pipe (using TableSyntax)" do
       using RSpec::Parameterized::TableSyntax


### PR DESCRIPTION
usage:
``` ruby
describe "ref and lazy" do
  let(:one) { 1 }
  let(:four) { 4 }

  where(:a, :b, :answer) do
    [
      [ref(:one), ref(:four), lazy { two + three }],
    ]
  end

  with_them do
    context "define two and three after where block" do
      let(:two) { 2 }
      let(:three) { 3 }

      it "should do additions" do
        expect(a + b).to eq answer
      end
    end
  end
end
```

This change should be a workaround for issue #8.