### PR TITLE
Changes to apply method calls recursively when parameter is Array or Hash.

### DIFF
--- a/lib/rspec/parameterized.rb
+++ b/lib/rspec/parameterized.rb
@@ -3,6 +3,7 @@ require 'parser'
 require 'unparser'
 require 'proc_to_ast'
 require 'rspec/parameterized/helper_methods'
+require 'rspec/parameterized/example_helper_methods'
 
 module RSpec
   module Parameterized
@@ -113,12 +114,10 @@ module RSpec
           pairs = [parameter.arg_names, param_set].transpose.to_h
           pretty_params = pairs.has_key?(:case_name) ? pairs[:case_name] : pairs.map {|name, val| "#{name}: #{params_inspect(val)}"}.join(", ")
           describe(pretty_params, *args) do
+            include ExampleHelperMethods
+
             pairs.each do |name, val|
-              if HelperMethods.applicable? val
-                let(name) { val.apply(self) }
-              else
-                let(name) { val }
-              end
+              let(name) { recursive_apply(val) }
             end
 
             singleton_class.module_eval do

--- a/lib/rspec/parameterized/example_helper_methods.rb
+++ b/lib/rspec/parameterized/example_helper_methods.rb
@@ -1,0 +1,19 @@
+module RSpec
+  module Parameterized
+    module ExampleHelperMethods
+      def recursive_apply(val)
+        return val.apply(self) if HelperMethods.applicable?(val)
+
+        if val.is_a?(Array)
+          return val.map { |child_val| recursive_apply(child_val) }
+        end
+
+        if val.is_a?(Hash)
+          return val.map { |key, value| [recursive_apply(key), recursive_apply(value)] }.to_h
+        end
+
+        val
+      end
+    end
+  end
+end

--- a/spec/parametarized_spec.rb
+++ b/spec/parametarized_spec.rb
@@ -192,46 +192,96 @@ describe RSpec::Parameterized do
   end
 
   describe "ref" do
-    let(:foo) { 1 }
+    context 'simple usecase' do
+      let(:foo) { 1 }
 
-    where(:value, :answer) do
-      [
-        [ref(:foo), 1],
-      ]
-    end
-
-    with_them do
-      it "let variable in same example group can be used" do
-        expect(value).to eq answer
+      where(:value, :answer) do
+        [
+          [ref(:foo), 1],
+        ]
       end
 
-      context "override let varibale" do
-        let(:foo) { 3 }
+      with_them do
+        it "let variable in same example group can be used" do
+          expect(value).to eq answer
+        end
 
-        it "can override let variable" do
-          expect(value).to eq 3
+        context "override let varibale" do
+          let(:foo) { 3 }
+
+          it "can override let variable" do
+            expect(value).to eq 3
+          end
+        end
+      end
+    end
+
+    context "recursive usecase" do
+      let(:foo) { 1 }
+
+      where(:value, :answer) do
+        [
+          [[ref(:foo), 2], [1, 2]],
+        ]
+      end
+
+      with_them do
+        it "let variable in same example group can be used" do
+          expect(value).to eq answer
+        end
+
+        context "override let varibale" do
+          let(:foo) { 3 }
+
+          it "can override let variable" do
+            expect(value).to eq [3, 2]
+          end
         end
       end
     end
   end
 
   describe "lazy" do
-    let(:one) { 1 }
-    let(:four) { 4 }
+    context "simple usecase" do
+      let(:one) { 1 }
+      let(:four) { 4 }
 
-    where(:a, :b, :answer) do
-      [
-        [ref(:one), ref(:four), lazy { two + three }],
-      ]
+      where(:a, :b, :answer) do
+        [
+          [ref(:one), ref(:four), lazy { two + three }],
+        ]
+      end
+
+      with_them do
+        context "define two and three after where block" do
+          let(:two) { 2 }
+          let(:three) { 3 }
+
+          it "should do additions" do
+            expect(a + b).to eq answer
+          end
+        end
+      end
     end
 
-    with_them do
-      context "define two and three after where block" do
-        let(:two) { 2 }
-        let(:three) { 3 }
+    context 'recursive usecase' do
+      let(:one) { 1 }
+      let(:four) { 4 }
 
-        it "should do additions" do
-          expect(a + b).to eq answer
+      where(:a, :b, :answer) do
+        [
+          [ref(:one), ref(:four), { result: lazy { two + three } }],
+        ]
+      end
+
+      with_them do
+        context "define two and three after where block" do
+          let(:two) { 2 }
+          let(:three) { 3 }
+
+          it "should do additions" do
+            expect(a + b).to eq answer[:result]
+          end
         end
       end
     end


### PR DESCRIPTION
## what

Implements `recursive_apply` method that is calls apply method of Arg class to children of Array or Hash parameters. 

## why

When I want to use array or hash parameters with ref or lazy, it didn't  applies properly.

```ruby
let(:foo) { 1 }

where(:values, :answer) do
  [
    [[ref(:foo), 2], 2],
  ]
end

with_them do
  it { expect(values.sum).to eq(answer) } # values => [:foo, 2] 
end
```