### PR TITLE
Fix uninitialized instance variable warning

### DIFF
--- a/lib/rspec/parameterized.rb
+++ b/lib/rspec/parameterized.rb
@@ -77,6 +77,7 @@ module RSpec
         opts = args.last.is_a?(Hash) ? args.pop : {}
         opts[:caller] = caller unless opts[:caller]
         args.push(opts)
+        @parameter ||= nil
 
         if @parameter.nil?
           @parameterized_pending_cases ||= []

--- a/lib/rspec/parameterized.rb
+++ b/lib/rspec/parameterized.rb
@@ -90,12 +90,11 @@ module RSpec
       private
       def set_parameters(arg_names, &b)
         @parameter = Parameter.new(arg_names, &b)
+        @parameterized_pending_cases ||= []
 
-        if @parameterized_pending_cases
-          @parameterized_pending_cases.each { |e|
-            define_cases(@parameter, *e[0], &e[1])
-          }
-        end
+        @parameterized_pending_cases.each { |e|
+          define_cases(@parameter, *e[0], &e[1])
+        }
       end
 
       def define_cases(parameter, *args, &block)


### PR DESCRIPTION
"warning: instance variable not initialized" is appeared if the `--warings` option of RSpec is enabled or set to `config.warnings = true`.

This warning is not displayed in Ruby 3.0 or later. However, I have fixed those for users using Ruby 2.6 and 2.7.
