### PR TITLE
Made MFA mandatory for gem releases

### DIFF
--- a/rspec-parameterized.gemspec
+++ b/rspec-parameterized.gemspec
@@ -9,6 +9,8 @@ Gem::Specification.new do |gem|
 I was inspired by [udzura's mock](https://gist.github.com/1881139).}
   gem.homepage      = "https://github.com/tomykaira/rspec-parameterized"
 
+  gem.metadata["rubygems_mfa_required"] = "true"
+
   gem.add_dependency('rspec', '>= 2.13', '< 4')
   gem.add_dependency('parser')
   gem.add_dependency('unparser')


### PR DESCRIPTION
# Motivation
I want to make MFA mandatory for gem security (supply chain attack)

https://blog.rubygems.org/2022/06/13/making-packages-more-secure.html

# What will change after merging this PR?
MFA is requested when `rake release` is running

```
$ bundle exec rake release

(snip)

You have enabled multi-factor authentication. Please enter OTP code.
Code:
```

Please enable MFA on own account 🙏 
https://rubygems.org/settings/edit

![image](https://user-images.githubusercontent.com/608755/174805175-cefaed0f-f943-42d1-ad36-43ef4cf26784.png)
