### PR TITLE
Support Ruby 3.2

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2']
 
     steps:
     - uses: actions/checkout@v2

--- a/rspec-parameterized.gemspec
+++ b/rspec-parameterized.gemspec
@@ -15,7 +15,7 @@ I was inspired by [udzura's mock](https://gist.github.com/1881139).}
   gem.add_dependency('parser')
   gem.add_dependency('unparser')
   gem.add_dependency('proc_to_ast')
-  gem.add_dependency('binding_ninja', '>= 0.2.3')
+  gem.add_dependency('binding_of_caller')
   gem.add_development_dependency('rake', '>= 12.0.0')
 
   gem.files         = `git ls-files`.split($\)


### PR DESCRIPTION
ref #80

`Refinement#include` is removed since ruby 3.2
https://bugs.ruby-lang.org/issues/17429

So I use `Refinement#import_methods` on ruby 3.2+

@joker1007 This patch actually works, but it's a little dirty...
What do you think?

Close #80