### PR TITLE
Reference LICENSE file in .gemspec

### DIFF
--- a/rspec-parameterized.gemspec
+++ b/rspec-parameterized.gemspec
@@ -10,6 +10,7 @@ I was inspired by [udzura's mock](https://gist.github.com/1881139).}
   gem.homepage      = "https://github.com/tomykaira/rspec-parameterized"
 
   gem.metadata["rubygems_mfa_required"] = "true"
+  gem.license       = "LicenseRef-LICENSE"
 
   gem.add_dependency('rspec-parameterized-core', '< 2')
   gem.add_dependency('rspec-parameterized-table_syntax', '< 2')


### PR DESCRIPTION
The rubygems.org page shows that the license is unknown because it references the .gemspec file which omits the license metadata. When reviewing the licenses for a project, I noticed that the gem wasn't showing a license, even though the repo mentions it's MIT licensed. It's possible others are also running into this, so I've added the license-ref in the .gemspec file.