### PR TITLE
Hard-code the license name

### DIFF
--- a/lib/rspec/parameterized/version.rb
+++ b/lib/rspec/parameterized/version.rb
@@ -1,5 +1,5 @@
 module RSpec
   module Parameterized
-    VERSION = "1.0.1"
+    VERSION = "1.0.2.rc1"
   end
 end

--- a/rspec-parameterized.gemspec
+++ b/rspec-parameterized.gemspec
@@ -10,7 +10,7 @@ I was inspired by [udzura's mock](https://gist.github.com/1881139).}
   gem.homepage      = "https://github.com/tomykaira/rspec-parameterized"
 
   gem.metadata["rubygems_mfa_required"] = "true"
-  gem.license       = "LicenseRef-LICENSE"
+  gem.license       = "MIT"
 
   gem.add_dependency('rspec-parameterized-core', '< 2')
   gem.add_dependency('rspec-parameterized-table_syntax', '< 2')


### PR DESCRIPTION
I merged #87 and published as v1.0.1. 

But, the licensing statement in the https://rubygems.org/gems/rspec-parameterized/versions/1.0.1 is odd. (maybe https://rubygems.org/ doesn't support LicenseRef...?)

<img width="231" alt="image" src="https://github.com/tomykaira/rspec-parameterized/assets/608755/50ebfcab-8eac-492a-93c1-94056ad59f32">

So I decided to specify the license directly